### PR TITLE
Bugfix/meta variables substitutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ catt
 /_build/
 /catt.opam
 /_install/
+test/test.catt

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -11,7 +11,7 @@ module Memo = struct
       Hashtbl.add tbl i res;
       res
 
-  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)),"builtin_id")) []
+  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)),"builtin_id"))
 end
 
 let comp_arity s =
@@ -36,7 +36,7 @@ let comp s =
   let build_comp i =
     let ps = comp_ps i in
     let ty = comp_ty i in
-    check_coh (Cohdecl (ps,ty, "builtin_comp")) []
+    check_coh (Cohdecl (ps,ty, "builtin_comp"))
   in
   Memo.find arity build_comp
 

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -11,7 +11,7 @@ module Memo = struct
       Hashtbl.add tbl i res;
       res
 
-  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)))) []
+  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)),"builtin_id")) []
 end
 
 let comp_arity s =
@@ -36,7 +36,7 @@ let comp s =
   let build_comp i =
     let ps = comp_ps i in
     let ty = comp_ty i in
-    check_coh (Cohdecl (ps,ty)) []
+    check_coh (Cohdecl (ps,ty, "builtin_comp")) []
   in
   Memo.find arity build_comp
 

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -11,7 +11,7 @@ module Memo = struct
       Hashtbl.add tbl i res;
       res
 
-  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)),"builtin_id"))
+  let id = check_coh (Cohdecl (Br[], Arr(Obj,Var(Db 0),Var(Db 0)),("builtin_id", 0, None)))
 end
 
 let comp_arity s =
@@ -36,7 +36,7 @@ let comp s =
   let build_comp i =
     let ps = comp_ps i in
     let ty = comp_ty i in
-    check_coh (Cohdecl (ps,ty, "builtin_comp"))
+    check_coh (Cohdecl (ps,ty, ("builtin_comp", 0, None)))
   in
   Memo.find arity build_comp
 

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -56,6 +56,9 @@ let exec_set o v =
   | _ when String.equal o "explicit_substitutions" ->
     let v = parse_bool v in
     Settings.explicit_substitutions := v
+  | _ when String.equal o "print_explicit_substitutions" ->
+    let v = parse_bool v in
+    Settings.print_explicit_substitutions := v
   | _ when String.equal o "implicit_suspension" ->
     let v = parse_bool v in
     Settings.implicit_suspension := v

--- a/lib/command.ml
+++ b/lib/command.ml
@@ -59,6 +59,9 @@ let exec_set o v =
   | _ when String.equal o "print_explicit_substitutions" ->
     let v = parse_bool v in
     Settings.print_explicit_substitutions := v
+  | _ when String.equal o "unroll_coherences" ->
+    let v = parse_bool v in
+    Settings.unroll_coherences := v
   | _ when String.equal o "implicit_suspension" ->
     let v = parse_bool v in
     Settings.implicit_suspension := v

--- a/lib/elaborate.ml
+++ b/lib/elaborate.ml
@@ -181,12 +181,7 @@ module Constraints_typing = struct
       match t with
     | Var v -> t, fst (List.assoc v ctx)
     | Meta_tm i -> t, List.assoc i meta_ctx
-    | Coh(c,s)->
-      let ps,ty =
-        match c with
-        | Cohdecl (ps,ty) -> ps,ty
-        | Cohchecked c -> Coh.forget c
-      in
+    | Coh(c,s)-> let ps,ty,_ = Unchecked.coh_data c in
       let s,tgt = Unchecked.sub_ps_to_sub s ps in
       let s = sub ctx meta_ctx s tgt cst in
       Coh(c,(List.map snd s)), Unchecked.ty_apply_sub ty s

--- a/lib/elaborate.ml
+++ b/lib/elaborate.ml
@@ -171,7 +171,7 @@ end
 module Constraints_typing = struct
 
   let rec tm ctx meta_ctx t cst =
-    Io.info ~v:4
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "constraint typing term %s in ctx %s, meta_ctx %s"
@@ -186,7 +186,7 @@ module Constraints_typing = struct
       let s = sub ctx meta_ctx s tgt cst in
       Coh(c,(List.map snd s)), Unchecked.ty_apply_sub ty s
   and sub src meta_ctx s tgt cst =
-    Io.info ~v:4
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "constraint typing substitution %s in ctx %s, \
@@ -204,7 +204,7 @@ module Constraints_typing = struct
       (x,u)::s
     |[],_::_ | _::_, [] -> Error.fatal "wrong number of arguments"
   and ty ctx meta_ctx t cst =
-    Io.info ~v:4
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "constraint typing type %s in ctx %s, meta_ctx %s"

--- a/lib/environment.ml
+++ b/lib/environment.ml
@@ -27,7 +27,7 @@ let add_let v c ?ty t =
   (t,ty)
 
 let add_coh v ps ty =
-  let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) in
+  let coh = check_coh (Cohdecl(ps,ty,(Var.to_string v, 0, None))) in
   let dim_input = Unchecked.dim_ps ps in
   let dim_output = Unchecked.dim_ty ty in
   Io.info ~v:4

--- a/lib/environment.ml
+++ b/lib/environment.ml
@@ -26,7 +26,7 @@ let add_let v c ?ty t =
   Hashtbl.add env v ({value = Tm (c,t); dim_input; dim_output})
 
 let add_coh v ps ty =
-  let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) [] in
+  let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) in
   let dim_input = Unchecked.dim_ps ps in
   let dim_output = Unchecked.dim_ty ty in
   Io.info ~v:2

--- a/lib/environment.ml
+++ b/lib/environment.ml
@@ -23,7 +23,8 @@ let add_let v c ?ty t =
          "defined term %s of type %s"
          (Unchecked.tm_to_string t)
          (Unchecked.ty_to_string ty)));
-  Hashtbl.add env v ({value = Tm (c,t); dim_input; dim_output})
+  Hashtbl.add env v ({value = Tm (c,t); dim_input; dim_output});
+  (t,ty)
 
 let add_coh v ps ty =
   let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) in
@@ -34,7 +35,8 @@ let add_coh v ps ty =
       (Printf.sprintf
          "defined coherence %s"
          (Var.to_string v)));
-  Hashtbl.add env v ({value = Coh coh; dim_input; dim_output})
+  Hashtbl.add env v ({value = Coh coh; dim_input; dim_output});
+  Cohchecked coh
 
 let find v =
   try Hashtbl.find env v

--- a/lib/environment.ml
+++ b/lib/environment.ml
@@ -17,10 +17,10 @@ let add_let v c ?ty t =
   let ty = Kernel.(Ty.forget (Tm.typ tm)) in
   let dim_input = Unchecked.dim_ctx c in
   let dim_output = Unchecked.dim_ty ty in
-  Io.info ~v:2
+  Io.info ~v:4
     (lazy
       (Printf.sprintf
-         "defined term %s of type %s"
+         "term %s of type %s added to environment"
          (Unchecked.tm_to_string t)
          (Unchecked.ty_to_string ty)));
   Hashtbl.add env v ({value = Tm (c,t); dim_input; dim_output});
@@ -30,10 +30,10 @@ let add_coh v ps ty =
   let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) in
   let dim_input = Unchecked.dim_ps ps in
   let dim_output = Unchecked.dim_ty ty in
-  Io.info ~v:2
+  Io.info ~v:4
     (lazy
       (Printf.sprintf
-         "defined coherence %s"
+         "coherence %s added to environment"
          (Var.to_string v)));
   Hashtbl.add env v ({value = Coh coh; dim_input; dim_output});
   Cohchecked coh

--- a/lib/environment.ml
+++ b/lib/environment.ml
@@ -26,7 +26,7 @@ let add_let v c ?ty t =
   Hashtbl.add env v ({value = Tm (c,t); dim_input; dim_output})
 
 let add_coh v ps ty =
-  let coh = check_coh (Cohdecl(ps,ty)) [] in
+  let coh = check_coh (Cohdecl(ps,ty,Var.to_string v)) [] in
   let dim_input = Unchecked.dim_ps ps in
   let dim_output = Unchecked.dim_ty ty in
   Io.info ~v:2

--- a/lib/environment.mli
+++ b/lib/environment.mli
@@ -7,8 +7,8 @@ type value =
 
 type t
 
-val add_let : Var.t -> ctx -> ?ty:ty -> tm -> unit
-val add_coh : Var.t -> ps -> ty -> unit
+val add_let : Var.t -> ctx -> ?ty:ty -> tm -> tm * ty
+val add_coh : Var.t -> ps -> ty -> coh
 val val_var : Var.t -> value
 val dim_output : Var.t -> int
 val dim_input : Var.t -> int

--- a/lib/functorialisation.ml
+++ b/lib/functorialisation.ml
@@ -122,7 +122,7 @@ let coh c s =
   with
     NonMaximal x ->
     Error.functorialisation
-      ("coherence: " ^ Unchecked.coh_to_string(c))
+      ("coherence: " ^ Unchecked.coh_to_string c)
       (Printf.sprintf "trying to functorialise with respect to variable %s which is not maximal" x)
 
 (*

--- a/lib/functorialisation.ml
+++ b/lib/functorialisation.ml
@@ -66,10 +66,10 @@ let target_subst l =
    Functorialisation of a coherence once with respect to a list of
    variables
 *)
-let coh_one_step ps ty l =
+let coh_one_step ps ty l name =
   let ctx_base = Unchecked.ps_to_ctx ps in
   let ctx,assocs = ctx_one_step ctx_base l in
-  let tm = Coh (Cohdecl(ps,ty),(Unchecked.identity_ps ctx_base)) in
+  let tm = Coh (Cohdecl(ps,ty,name),(Unchecked.identity_ps ctx_base)) in
   let tm_f = Unchecked.tm_apply_sub tm (target_subst assocs) in
   let ty = Arr (ty, tm, tm_f) in
   let ps = Kernel.PS.(forget (mk (Kernel.Ctx.check ctx))) in
@@ -81,22 +81,22 @@ let coh_one_step ps ty l =
    Functorialisation of a coherence possibly multiple times, with
    respect to a functorialisation data
 *)
-let rec coh (ps,ty) s =
+let rec coh (ps,ty) s name =
   let ct = Unchecked.ps_to_ctx ps in
   let l, next = list_functorialised ct s in
-  if l <> [] then coh (coh_one_step ps ty l) next
+  if l <> [] then coh (coh_one_step ps ty l name) next name
   else ps,ty
 
 (*
    Functorialisation of a coherence: exposed function
 *)
 let coh c s =
-  let ps,ty = Unchecked.coh_data c in
-  try let ps,ty = coh (ps,ty) s in Cohdecl(ps,ty)
+  let ps,ty,name = Unchecked.coh_data c in
+  try let ps,ty = coh (ps,ty) s name in Cohdecl(ps,ty,name^"F")
   with
     NonMaximal x ->
     Error.functorialisation
-      ("coherence: " ^ Unchecked.coh_to_string(Cohdecl(ps,ty)))
+      ("coherence: " ^ Unchecked.coh_to_string(Cohdecl(ps,ty,name)))
       (Printf.sprintf "trying to functorialise with respect to variable %s which is not maximal" x)
 
 (*
@@ -128,15 +128,11 @@ let rec tm_one_step t l =
     begin
       match l with
       | _::_ ->
-        let ps = match c with
-          | Cohdecl(ps,_) -> ps
-          | Cohchecked c -> fst (Coh.forget c)
-        in
+        let ps,ty,name = Unchecked.coh_data c in
         let cohf =
           let places = find_places (Unchecked.ps_to_ctx ps) s (List.map fst l) in
-          let ps,ty = Unchecked.coh_data c in
-          let ps,ty = coh_one_step ps ty places in
-          Cohdecl(ps,ty)
+          let ps,ty = coh_one_step ps ty places name in
+          Cohdecl(ps,ty,"name"^"F")
         in
         let sf = sub s l in
         let l' = target_subst l in

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -71,7 +71,7 @@ end
     List.concat (List.map Tm.free_vars s.list)
 
   let check src s tgt =
-    Io.info ~v:3
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "building kernel substitution \
@@ -387,7 +387,7 @@ struct
     | Arr(_,_,v) -> v
 
   let rec check c t =
-    Io.info ~v:3
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "building kernel type %s in context %s"
@@ -456,7 +456,7 @@ struct
   let _to_string tm = Unchecked.tm_to_string (forget tm)
 
   let check c ?ty t =
-    Io.info ~v:3
+    Io.info ~v:5
       (lazy
         (Printf.sprintf
            "building kernel term %s in context %s"
@@ -515,7 +515,7 @@ struct
     try
       match coh with
       | Unchecked_types.Cohdecl (ps,t,name) ->
-        Io.info ~v:3
+        Io.info ~v:5
           (lazy
             (Printf.sprintf "checking coherence (%s,%s)"
                (Unchecked.ps_to_string ps)

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -538,7 +538,7 @@ struct
   let forget (ps,ty,name) = PS.forget ps, Ty.forget ty, name
 
   let to_string (ps,ty,name) =
-    if !Settings.verbosity <= 3 then name else
+    if !Settings.verbosity <= 5 then name else
     Printf.sprintf "Coh(%s,%s)" (PS.to_string ps) (Ty.to_string ty)
 end
 
@@ -641,7 +641,7 @@ end = struct
     | t::s -> Printf.sprintf "%s %s" (sub_ps_to_string s)  (tm_to_string t)
   and coh_to_string = function
     | Unchecked_types.Cohdecl(ps,ty,name) ->
-      if !Settings.verbosity <= 3 then name
+      if !Settings.verbosity <= 5 then name
       else
         Printf.sprintf "coh(%s,%s)"
           (ps_to_string ps)

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -538,7 +538,7 @@ struct
   let forget (ps,ty,name) = PS.forget ps, Ty.forget ty, name
 
   let to_string (ps,ty,name) =
-    if !Settings.verbosity <= 5 then name else
+    if not (!Settings.unroll_coherences) then name else
     Printf.sprintf "Coh(%s,%s)" (PS.to_string ps) (Ty.to_string ty)
 end
 
@@ -638,7 +638,7 @@ end = struct
     | Unchecked_types.Var v -> Var.to_string v
     | Unchecked_types.Meta_tm i -> Printf.sprintf "_tm%i" i
     | Unchecked_types.Coh (c,s) ->
-      if !Settings.verbosity <= 5 then
+      if not (!Settings.unroll_coherences) then
         Printf.sprintf "(%s%s)"
           (coh_to_string c)
           (sub_ps_to_string s)
@@ -654,7 +654,7 @@ end = struct
       else sub_ps_to_string s
   and coh_to_string = function
     | Unchecked_types.Cohdecl(ps,ty,name) ->
-      if !Settings.verbosity <= 5 then name
+      if not (!Settings.unroll_coherences) then name
       else
         Printf.sprintf "coh(%s,%s)"
           (ps_to_string ps)

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -649,7 +649,7 @@ end = struct
   and sub_ps_to_string = function
     | [] -> ""
     | (t,expl)::s ->
-      if(expl || !Settings.verbosity >= 3) then
+      if(expl || !Settings.print_explicit_substitutions) then
         Printf.sprintf "%s %s" (sub_ps_to_string s)  (tm_to_string t)
       else sub_ps_to_string s
   and coh_to_string = function

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -582,7 +582,6 @@ end = struct
   type sub = (Var.t * tm) list
 
   type meta_ctx = ((int * ty) list)
-
 end
 and Unchecked : sig
   val ps_to_string : Unchecked_types.ps -> string

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -625,17 +625,27 @@ end = struct
     | Unchecked_types.Meta_ty i -> Printf.sprintf "_ty%i" i
     | Unchecked_types.Obj -> "*"
     | Unchecked_types.Arr (a,u,v) ->
-      Printf.sprintf "%s | %s -> %s"
-        (ty_to_string a)
-        (tm_to_string u)
-        (tm_to_string v)
+      if !Settings.verbosity >= 3 then
+        Printf.sprintf "%s | %s -> %s"
+          (ty_to_string a)
+          (tm_to_string u)
+          (tm_to_string v)
+      else
+        Printf.sprintf "%s -> %s"
+          (tm_to_string u)
+          (tm_to_string v)
   and tm_to_string = function
     | Unchecked_types.Var v -> Var.to_string v
     | Unchecked_types.Meta_tm i -> Printf.sprintf "_tm%i" i
     | Unchecked_types.Coh (c,s) ->
-      Printf.sprintf "%s[%s]"
-        (coh_to_string c)
-        (sub_ps_to_string s)
+      if !Settings.verbosity <= 5 then
+        Printf.sprintf "(%s%s)"
+          (coh_to_string c)
+          (sub_ps_to_string s)
+      else
+        Printf.sprintf "%s[%s]"
+          (coh_to_string c)
+          (sub_ps_to_string s)
   and sub_ps_to_string = function
     | [] -> ""
     | t::s -> Printf.sprintf "%s %s" (sub_ps_to_string s)  (tm_to_string t)

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -14,6 +14,8 @@ module Var : sig
 end
 
 module rec Unchecked_types : sig
+  type coh_pp_data = string * int * functorialisation_data option
+
   type ps = Br of ps list
 
   type ty =
@@ -25,7 +27,7 @@ module rec Unchecked_types : sig
     | Meta_tm of int
     | Coh of coh * sub_ps
   and coh =
-    | Cohdecl of ps * ty * string
+    | Cohdecl of ps * ty * coh_pp_data
     | Cohchecked of Coh.t
   and sub_ps = (tm * bool) list
   type ctx = (Var.t * (ty * bool)) list
@@ -36,7 +38,7 @@ end
 
 and Coh : sig
   type t
-  val forget : t -> Unchecked_types.ps * Unchecked_types.ty * string
+  val forget : t -> Unchecked_types.ps * Unchecked_types.ty * Unchecked_types.coh_pp_data
 end
 
 open Unchecked_types
@@ -70,7 +72,7 @@ module Unchecked : sig
   val ps_to_string : ps -> string
   val ty_to_string : ty -> string
   val tm_to_string : tm -> string
-  val sub_ps_to_string : sub_ps -> string
+  val sub_ps_to_string : ?func : functorialisation_data -> sub_ps -> string
   val ctx_to_string : ctx -> string
   val sub_to_string : sub -> string
   val coh_to_string : Unchecked_types.coh -> string
@@ -93,7 +95,7 @@ module Unchecked : sig
   val suspend_ctx : ctx -> ctx
   val suspend_sub_ps : sub_ps -> sub_ps
   val check_equal_coh : coh -> coh -> unit
-  val coh_data :Unchecked_types.coh -> Unchecked_types.ps * Unchecked_types.ty * string
+  val coh_data :Unchecked_types.coh -> Unchecked_types.ps * Unchecked_types.ty * Unchecked_types.coh_pp_data
 end
 
 val check_term : Ctx.t -> ?ty:ty -> tm -> Tm.t

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -25,7 +25,7 @@ module rec Unchecked_types : sig
     | Meta_tm of int
     | Coh of coh * sub_ps
   and coh =
-    | Cohdecl of ps * ty
+    | Cohdecl of ps * ty * string
     | Cohchecked of Coh.t
   and sub_ps = tm list
   type ctx = (Var.t * (ty * bool)) list
@@ -34,7 +34,7 @@ module rec Unchecked_types : sig
 end
 and Coh : sig
   type t
-  val forget : t -> Unchecked_types.ps * Unchecked_types.ty
+  val forget : t -> Unchecked_types.ps * Unchecked_types.ty * string
 end
 
 open Unchecked_types
@@ -92,7 +92,7 @@ module Unchecked : sig
   val suspend_ctx : ctx -> ctx
   val suspend_sub_ps : sub_ps -> sub_ps
   val check_equal_coh : coh -> coh -> unit
-  val coh_data :Unchecked_types.coh -> Unchecked_types.ps * Unchecked_types.ty
+  val coh_data :Unchecked_types.coh -> Unchecked_types.ps * Unchecked_types.ty * string
 end
 
 val check_term : Ctx.t -> ?ty:ty -> tm -> Tm.t

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -27,7 +27,7 @@ module rec Unchecked_types : sig
   and coh =
     | Cohdecl of ps * ty * string
     | Cohchecked of Coh.t
-  and sub_ps = tm list
+  and sub_ps = (tm * bool) list
   type ctx = (Var.t * (ty * bool)) list
   type sub = (Var.t * tm) list
   type meta_ctx = ((int * ty) list)

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -96,4 +96,4 @@ module Unchecked : sig
 end
 
 val check_term : Ctx.t -> ?ty:ty -> tm -> Tm.t
-val check_coh : Unchecked_types.coh -> (Var.t * int) list -> Coh.t
+val check_coh : Unchecked_types.coh -> Coh.t

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -31,7 +31,9 @@ module rec Unchecked_types : sig
   type ctx = (Var.t * (ty * bool)) list
   type sub = (Var.t * tm) list
   type meta_ctx = ((int * ty) list)
+
 end
+
 and Coh : sig
   type t
   val forget : t -> Unchecked_types.ps * Unchecked_types.ty * string
@@ -63,7 +65,6 @@ module PS : sig
   val mk : Ctx.t -> t
   val forget : t -> ps
 end
-
 
 module Unchecked : sig
   val ps_to_string : ps -> string

--- a/lib/kernel.mli
+++ b/lib/kernel.mli
@@ -19,19 +19,19 @@ module rec Unchecked_types : sig
   type ps = Br of ps list
 
   type ty =
-    | Meta_ty of int
+    | Meta_ty of int * sub option
     | Obj
     | Arr of ty * tm * tm
   and tm =
     | Var of Var.t
-    | Meta_tm of int
+    | Meta_tm of int * sub option
     | Coh of coh * sub_ps
   and coh =
     | Cohdecl of ps * ty * coh_pp_data
     | Cohchecked of Coh.t
   and sub_ps = (tm * bool) list
+  and sub = (Var.t * tm) list
   type ctx = (Var.t * (ty * bool)) list
-  type sub = (Var.t * tm) list
   type meta_ctx = ((int * ty) list)
 
 end

--- a/lib/settings.ml
+++ b/lib/settings.ml
@@ -4,3 +4,4 @@ let use_builtins = ref true
 let pretty_printing = ref true
 let implicit_suspension = ref true
 let debug = ref false
+let print_explicit_substitutions = ref false

--- a/lib/settings.ml
+++ b/lib/settings.ml
@@ -5,3 +5,4 @@ let pretty_printing = ref true
 let implicit_suspension = ref true
 let debug = ref false
 let print_explicit_substitutions = ref false
+let unroll_coherences = ref false

--- a/lib/settings.mli
+++ b/lib/settings.mli
@@ -1,5 +1,6 @@
 val explicit_substitutions : bool ref
 val print_explicit_substitutions : bool ref
+val unroll_coherences : bool ref
 val verbosity : int ref
 val use_builtins : bool ref
 val pretty_printing : bool ref

--- a/lib/settings.mli
+++ b/lib/settings.mli
@@ -1,4 +1,5 @@
 val explicit_substitutions : bool ref
+val print_explicit_substitutions : bool ref
 val verbosity : int ref
 val use_builtins : bool ref
 val pretty_printing : bool ref

--- a/lib/suspension.ml
+++ b/lib/suspension.ml
@@ -19,7 +19,7 @@ let coh i coh =
   | None -> Cohchecked coh
   | Some 0 -> Cohchecked coh
   | Some _ ->
-    let p,t,name = Coh.forget coh in
+    let p,t,(name,susp,f) = Coh.forget coh in
     let p = ps i p in
     let t = ty i t in
-    Cohdecl(p,t, "!"^name)
+    Cohdecl(p,t,(name,susp+1,f))

--- a/lib/suspension.ml
+++ b/lib/suspension.ml
@@ -19,7 +19,7 @@ let coh i coh =
   | None -> Cohchecked coh
   | Some 0 -> Cohchecked coh
   | Some _ ->
-    let p,t = Coh.forget coh in
+    let p,t,_ = Coh.forget coh in
     let p = ps i p in
     let t = ty i t in
-    Cohdecl(p,t)
+    Cohdecl(p,t, "dummy")       (* TODO *)

--- a/lib/suspension.ml
+++ b/lib/suspension.ml
@@ -19,7 +19,7 @@ let coh i coh =
   | None -> Cohchecked coh
   | Some 0 -> Cohchecked coh
   | Some _ ->
-    let p,t,_ = Coh.forget coh in
+    let p,t,name = Coh.forget coh in
     let p = ps i p in
     let t = ty i t in
-    Cohdecl(p,t, "dummy")       (* TODO *)
+    Cohdecl(p,t, "!"^name)

--- a/lib/translate_raw.ml
+++ b/lib/translate_raw.ml
@@ -8,11 +8,11 @@ let meta_namer_ty = ref 0
 let meta_namer_tm = ref 0
 
 let new_meta_ty () =
-  let meta = Meta_ty !meta_namer_ty in
+  let meta = Meta_ty (!meta_namer_ty, None) in
   meta_namer_ty := !meta_namer_ty + 1; meta
 let new_meta_tm () =
   let i = !meta_namer_tm in
-  let meta = Meta_tm i in
+  let meta = Meta_tm (i, None) in
   meta_namer_tm := !meta_namer_tm + 1;
   meta, (i, new_meta_ty())
 

--- a/lib/translate_raw.ml
+++ b/lib/translate_raw.ml
@@ -21,7 +21,7 @@ let rec tm tm =
   let make_coh coh s susp =
     let coh = Suspension.coh susp coh in
     let coh = Functorialisation.coh coh (List.map snd s) in
-    let ps = fst (Unchecked.coh_data coh) in
+    let ps,_,_ = Unchecked.coh_data coh in
     let s, meta_types = sub_ps s ps in
     Coh(coh,s), meta_types
   in

--- a/lib/translate_raw.ml
+++ b/lib/translate_raw.ml
@@ -48,22 +48,38 @@ let rec tm tm =
   | Sub (Letin_tm _,_,_) | Sub(Sub _,_,_) | Sub(Meta,_,_)
   | Sub(Builtin _, _,_) | Letin_tm _ -> Error.fatal("ill-formed term")
 and sub_ps s ps =
-  let sub,meta_types = sub s (Unchecked.ps_to_ctx ps) in
-  List.map snd sub, meta_types
-and sub s tgt =
+  let tgt = Unchecked.ps_to_ctx ps in
+  let rec aux s tgt =
+    match s,tgt with
+    | [],[] -> [],[]
+    | (t,_)::s, (_,(_, true))::tgt ->
+      let t,meta_types_t = tm t in
+      let s,meta_types_s = aux s tgt in
+      (t, true)::s,  List.append meta_types_t meta_types_s
+    | (t,_)::s, (_,(_, false))::tgt when !Settings.explicit_substitutions ->
+      let t,meta_types_t = tm t in
+      let s,meta_types_s = aux s tgt in
+      (t, false)::s,  List.append meta_types_t meta_types_s
+    | s, (_,(_,false))::tgt ->
+      let t,meta_type = new_meta_tm() in
+      let s,meta_types_s = aux s tgt in
+      (t, false)::s, meta_type::meta_types_s
+    | _::_, [] |[],_::_ -> raise WrongNumberOfArguments
+  in aux s tgt
+and sub s  tgt  =
   match s,tgt with
   | [],[] -> [],[]
-  | (t,_)::s, (x,(_, true))::tgt ->
+  | (t,_)::s, (x,(_, e))::tgt when e || !Settings.explicit_substitutions ->
     let t, meta_types_t = tm t in
     let s,meta_types_s = sub s tgt in
     (x,t)::s,  List.append meta_types_t meta_types_s
-  | (t,_)::s, (x,(_, false))::tgt when !Settings.explicit_substitutions ->
-    let t, meta_types_t = tm t in
-    let s,meta_types_s = sub s tgt in
-    (x, t)::s, List.append meta_types_t meta_types_s
-  | s , (x,(_, false))::tgt ->
+  | (_::_) as s , (x,(_,_))::tgt ->
     let t, meta_type = new_meta_tm() in
     let s,meta_types_s = sub s tgt in
+    (x, t)::s, meta_type::meta_types_s
+  | [], (x,(_,false))::tgt ->
+    let t, meta_type = new_meta_tm() in
+    let s,meta_types_s = sub [] tgt in
     (x, t)::s, meta_type::meta_types_s
   | _::_, [] |[],_::_ -> raise WrongNumberOfArguments
 
@@ -112,5 +128,5 @@ let ctx c =
 let rec sub_to_suspended = function
   | [] ->
     let (m1,mc1),(m0,mc0) = new_meta_tm(), new_meta_tm() in
-    [ m1; m0], [mc1; mc0]
+    [ m1, false; m0, false], [mc1; mc0]
   | t::s -> let s,m = sub_to_suspended s in t::s, m

--- a/lib/translate_raw.mli
+++ b/lib/translate_raw.mli
@@ -6,3 +6,6 @@ val tm : tmR -> tm * meta_ctx
 val ty : tyR -> ty * meta_ctx
 val ctx : (Var.t * tyR) list -> ctx * meta_ctx
 val sub_to_suspended : sub_ps -> sub_ps * meta_ctx
+
+val new_meta_ty : unit -> ty
+val new_meta_tm : unit -> tm * (int * ty)

--- a/test/pretty-print.catt
+++ b/test/pretty-print.catt
@@ -1,0 +1,29 @@
+set explicit_substitutions = t
+
+coh id (x : *) : x -> x
+coh comp (x : *) (y : *) (f : x -> y) (z : *) (g : y -> z) : x -> z
+coh whiskr (x : *) (y : *) (f : x -> y) (f' : x -> y) (a : f -> f')
+                   (z : *) (g : y -> z) : comp x y f z g -> comp x y f' z g
+coh whiskl (x : *) (y : *) (f : x -> y)
+                   (z : *) (g : y -> z) (g' : y -> z) (a : g -> g') :  comp x y f z g -> comp x y f z g'
+coh horiz (x : *) (y : *) (f : x -> y) (f' : x -> y) (a : f -> f')
+                  (z : *) (g : y -> z) (g' : y -> z) (b : g -> g') :
+		  comp x y f z g -> comp x y f' z g'
+
+let sq (x : *) (f : x -> x) = comp x x f x f
+
+let cbd (x : *) (f : x -> x) : x -> x = comp x x f x (comp x x f x f)
+
+
+set explicit_substitutions=f
+set verbosity = 2
+
+coh simpl (x : *) : sq (id x) -> id x
+
+coh test (x(f(a)g)y) : comp [a] [id (id y)] -> comp [a] (id y)
+let 302 (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (b : f -> g) (F : a -> b) (z : *) (h : y -> z) (k : y -> z) (c : h -> k) = comp [[F]] [c]
+let 202 (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (z : *) (h : y -> z) (k : y -> z) (c : h -> k) = comp [a] [c]
+let 302bis (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (b : f -> g) (F : a -> b) (z : *) (h : y -> z) (k : y -> z) (c : h -> k) = 202 [F] c
+
+set unroll_coherences = t
+check (x : *) (f : x -> x) = comp (sq f) (cbd f)

--- a/test/pretty-print.catt
+++ b/test/pretty-print.catt
@@ -25,5 +25,9 @@ let 302 (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (b : f -> g) (F :
 let 202 (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (z : *) (h : y -> z) (k : y -> z) (c : h -> k) = comp [a] [c]
 let 302bis (x : *) (y : *) (f : x -> y) (g : x -> y) (a : f -> g) (b : f -> g) (F : a -> b) (z : *) (h : y -> z) (k : y -> z) (c : h -> k) = 202 [F] c
 
+
 set unroll_coherences = t
 check (x : *) (f : x -> x) = comp (sq f) (cbd f)
+
+set unroll_coherences = f
+check (x : *) (f : x -> x) = test [id (id f)]

--- a/test/test.catt
+++ b/test/test.catt
@@ -14,6 +14,8 @@ let sq (x : *) (f : x -> x) = comp x x f x f
 
 let cbd (x : *) (f : x -> x) : x -> x = comp x x f x (comp x x f x f)
 
+set verbosity = 3
+
 coh simpl (x : *) : sq x (id x) -> id x
 
 check (x : *) (f : x -> x) = comp x x (sq x f) x (cbd x f)


### PR DESCRIPTION
Add substituted meta variables to the syntax, and use them inside the typing by constraints algorithm

These were not previously necessary, as we did not have coherence with meta_variables in the types. However, for automatic generation, it is much more convenient to have those, and as such, this MR changes the way type meta variables are handled.

When a type meta variable is hit by a substitution, it does not compute further, and saves it is is. During the unification algorithm, we unfold the type using new term meta variables. When further substituted those meta variables become term that compute under the substitution 