### PR TITLE
use queues from Janestreet's stdlib for constraints

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,7 @@
  (name catt)
  (public_name catt)
  (modules_without_implementation raw_types)
+ (libraries base)
  ;(libraries landmarks)
  ;(preprocess (pps landmarks-ppx --auto))
 )


### PR DESCRIPTION
Change the datatype for handling constraints using queues. I changed to Janestreet's implementation of queues because they provide Queue.map