### PR TITLE
Flaked the nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ catt
 /catt.opam
 /_install/
 test/test.catt
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705496572,
+        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "An infinity-categorical coherence typechecker";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = (import nixpkgs { inherit system; });
+      in {
+        # Exports a package that can be built with
+        # nix built. The build environment can be accessed
+        # via nix develop.
+        packages = rec {
+          default = self.packages.${system}.catt;
+          catt = pkgs.callPackage
+            ({ stdenv, dune_3, ocaml, opam, ocamlPackages, ... }:
+              stdenv.mkDerivation {
+                pname = "catt";
+                version = "0.2.0";
+                src = ./.;
+                buildInputs = [ dune_3 ocaml opam ] ++ (with ocamlPackages; [
+                  fmt
+                  js_of_ocaml
+                  js_of_ocaml-ppx
+                  menhir
+                  sedlex
+                ]);
+                buildPhase = ''
+                  rm -rf result
+                  dune build
+                '';
+                installPhase = ''
+                  mkdir -p $out/bin
+                  install -Dm755 _build/default/bin/catt.exe $out/bin
+                  mkdir -p $out/web
+                  #install -Dm644 _build/default/web/index.html $out/web
+                  #install -Dm644 _build/default/web/*.js $out/web
+                '';
+              }) { };
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,4 +3,4 @@ in fetchTarball {
   url =
     lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
   sha256 = lock.nodes.flake-compat.locked.narHash;
-}) { src = ./.; }).defaultNix
+}) { src = ./.; }).shellNix


### PR DESCRIPTION
I wrote a nix flake using the existing derivation. The package can now be built either with `nix-build` or `nix build`, while the development shell can be accessed either by `nix-shell` or `nix develop`.