### PR TITLE
Refactor the building process

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,18 +1,13 @@
-(lang dune 3.7)
+(lang dune 3.16)
 
 (name catt)
-
 (generate_opam_files true)
-
-(source
-  (github thibautbenjamin/catt))
-
-(authors "Thibaut Benjamin")
-
-(maintainers "Thibaut Benjamin")
-
+(source (github thibautbenjamin/catt))
+(authors "Thibaut Benjamin"
+         "Chiara Sarti")
+(maintainers "Thibaut Benjamin"
+             "Chiara Sarti")
 (license MIT)
-
 (using menhir 2.0)
 
 (package

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705496572,
-        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Various things are a bit ugly in the current build process of catt and the CI.

This branch is there to:
- clean up the flake defining the package
- cleanup the various dune files
- make the CI use the flake definition, so that when the build process is modified, the CI adapts
- add linting and code formatting to the CI
- change the testing in the CI to use dune, for more accurate testing with oracles