### PR TITLE
Feature/better contexts

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -31,8 +31,8 @@ rule token = parse
   | "@" { AT }
   | "" { IGNORE }
   | ['0'-'9']* as str { INT str }
-  | (['a'-'z''A'-'Z''0'-'9']['-''+''a'-'z''A'-'Z''0'-'9''_''@''>''{''}''/'',''\'']* as str) { IDENT str }
+  | (['a'-'z''A'-'Z''0'-'9'](['-''+''a'-'z''A'-'Z''0'-'9''_''@''>''<''{''}''/''\'']*) as str) { IDENT str }
   | space+ { token lexbuf }
   | "#"[^'\n']* { token lexbuf }
   | "\n" { Lexing.new_line lexbuf; token lexbuf }
-| eof { EOF }
+  | eof { EOF }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -72,8 +72,12 @@ cmd:
   | SET IDENT EQUAL IDENT { Set ($2,$4) }
   | SET IDENT EQUAL INT { Set ($2,$4) }
 
+args_of_same_ty :
+  | IDENT COL tyexpr { [Var.make_var $1, $3], $3 }
+  | IDENT COMA args_of_same_ty { (Var.make_var $1, snd $3)::(fst $3), snd $3 }
+
 nonempty_args :
-  | LPAR IDENT COL tyexpr RPAR args { (Var.make_var $2, $4)::$6 }
+  | LPAR args_of_same_ty RPAR args { List.append (fst $2) $4 }
 
 args:
   | nonempty_args { $1 }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -51,33 +51,37 @@ prog:
   | EOF { [] }
 
 cmd:
-  | COH IDENT ps COL tyexpr { Coh (Var.make_var $2,$3,$5) }
-  | COH BUILTIN ps COL tyexpr
+  | COH IDENT args_or_ps COL tyexpr { Coh (Var.make_var $2,$3,$5) }
+  | COH BUILTIN args_or_ps COL tyexpr
     { if !Settings.use_builtins then raise (Error.ReservedName $2)
       else Coh (Var.make_var $2,$3,$5) }
-  | CHECK args COL tyexpr EQUAL tmexpr { Check ($2,$6, Some $4) }
-  | CHECK args EQUAL tmexpr { Check ($2,$4,None) }
-  | LET IDENT args COL tyexpr EQUAL tmexpr
+  | CHECK args_or_ps COL tyexpr EQUAL tmexpr { Check ($2,$6, Some $4) }
+  | CHECK args_or_ps EQUAL tmexpr { Check ($2,$4,None) }
+  | LET IDENT args_or_ps COL tyexpr EQUAL tmexpr
     { Decl (Var.make_var $2,$3,$7,Some $5) }
-  | LET IDENT args EQUAL tmexpr
+  | LET IDENT args_or_ps EQUAL tmexpr
     { Decl (Var.make_var $2,$3,$5, None) }
-  | LET BUILTIN args COL tyexpr EQUAL tmexpr
+  | LET BUILTIN args_or_ps COL tyexpr EQUAL tmexpr
     {
       if !Settings.use_builtins then raise (Error.ReservedName $2)
       else Decl (Var.make_var $2,$3,$7,Some $5)
     }
-  | LET BUILTIN args EQUAL tmexpr
+  | LET BUILTIN args_or_ps EQUAL tmexpr
     { if !Settings.use_builtins then raise (Error.ReservedName $2)
       else Decl (Var.make_var $2,$3,$5, None) }
   | SET IDENT EQUAL IDENT { Set ($2,$4) }
   | SET IDENT EQUAL INT { Set ($2,$4) }
 
 nonempty_args :
-  | args LPAR IDENT COL tyexpr RPAR { (Var.make_var $3, $5)::$1 }
+  | LPAR IDENT COL tyexpr RPAR args { (Var.make_var $2, $4)::$6 }
 
 args:
   | nonempty_args { $1 }
   | { [] }
+
+args_or_ps :
+  | args { List.rev $1 }
+  | ps { $1 }
 
 nonempty_sub:
   | sub simple_tmexpr { ($2,0)::$1 }
@@ -136,7 +140,6 @@ tyexpr:
   | subst_tmexpr MOR subst_tmexpr { ArrR ($1,$3) }
 
 ps :
-  | LPAR IDENT COL tyexpr RPAR args { List.append $6 [(Var.make_var $2, $4)] }
   | LPAR IDENT RPAR { context_of_annotated_ps (Br ([], Var.make_var $2)) }
   | LPAR IDENT simpl_ps ps_list IDENT RPAR
     {

--- a/test.t/coverage/eckmann-hilton-unoptimized.catt
+++ b/test.t/coverage/eckmann-hilton-unoptimized.catt
@@ -195,11 +195,11 @@ coh rrrew2A (x(f(a0(al0(c)al1)a1)g)y(h(b0(bet0(d)bet1)b1)k)z) :
             rrew2A al0 bet0 -> rrew2A al1 bet1
 
 ### interchanging left and right unitors when possible
-coh id2@/1-,2-/  (x) :  id2@1- (id x) -> id2@2- (id x)
-coh id2@/1-,2-/- (x) :  id2@2- (id x) -> id2@1- (id x)
+coh id2@/1-/2-/  (x) :  id2@1- (id x) -> id2@2- (id x)
+coh id2@/1-/2-/- (x) :  id2@2- (id x) -> id2@1- (id x)
 
-coh id2@/1,2/  (x) : id2@1 (id x) -> id2@2 (id x)
-coh id2@/1,2/- (x) : id2@2 (id x) -> id2@1 (id x)
+coh id2@/1/2/  (x) : id2@1 (id x) -> id2@2 (id x)
+coh id2@/1/2/- (x) : id2@2 (id x) -> id2@1 (id x)
 
 ### cancelling left and right unitors
 coh id2@2@1U  (x) : comp (id2@2 (id x)) (id2@1- (id x)) -> id (comp (id x) (id x))
@@ -538,6 +538,6 @@ coh exchU (x(f(a)g)y(h(b)k)z) : comp (exch a b) (exch- a b) -> id (comp (rew2@1 
 let eh (x : *) (a : id x -> id x) (b : id x  -> id x) =
     comp5 (rew2A (rew2@1id@2- a) (rew2@2id@1- b))
 	  (red3F (id2@2- (id x)) (rew2@1 a (id x)) (id2@2@1U x) (rew2@2 (id x) b) (id2@1 (id x)))
-	  (rew3A (id2@/1-,2-/- x) (exch a b) (id2@/1,2/ x))
+	  (rew3A (id2@/1-/2-/- x) (exch a b) (id2@/1/2/ x))
 	  (red3F- (id2@1- (id x)) (rew2@2 (id x) b) (id2@1@2U- x) (rew2@1 a (id x)) (id2@2 (id x)))
 	  (rew2A (rew2@2id@1 b) (rew2@1id@2 a))

--- a/test.t/features/contexts.catt
+++ b/test.t/features/contexts.catt
@@ -1,0 +1,2 @@
+coh whisk (x(f(a)g)y(h)z) : comp  f h -> comp g h
+let composition (x, y, z : *) (f, g : x -> y) (h : y -> z) (a : f -> g) = whisk a h

--- a/test.t/features/ps-syntax.catt
+++ b/test.t/features/ps-syntax.catt
@@ -14,3 +14,5 @@ let cbd (x : *) (f : x -> x) : x -> x = comp f (comp f f)
 coh simpl (x) : sq (id x) -> id x
 
 check (x : *) (f : x -> x) = comp (sq f) (cbd f)
+
+let comp-bis (x(f)y(g)z)  = comp f g

--- a/test.t/run.t
+++ b/test.t/run.t
@@ -80,6 +80,12 @@
   [=^.^=] coh unbiase = (_builtin_comp  _ _ (_builtin_comp  _ _ f _ g) _ h) -> (_builtin_comp  _ _ f _ g _ h)
   [=I.I=] successfully defined unbiase.
 
+  $ catt features/contexts.catt
+  [=^.^=] coh whisk = (_builtin_comp  f h) -> (_builtin_comp  g h)
+  [=I.I=] successfully defined whisk.
+  [=^.^=] let composition = (whisk  a h)
+  [=I.I=] successfully defined term (whisk a h) of type (builtin_comp2 f h) -> (builtin_comp2 g h).
+
   $ catt features/suspension.catt
   [=^.^=] let comp2 = (!1 _builtin_comp  a b)
   [=I.I=] successfully defined term (!1builtin_comp2 a b) of type f -> h.
@@ -488,14 +494,14 @@
   [=I.I=] successfully defined rrew2idA.
   [=^.^=] coh rrrew2A = (rrew2A  al0 bet0) -> (rrew2A  al1 bet1)
   [=I.I=] successfully defined rrrew2A.
-  [=^.^=] coh id2@/1-,2-/ = (id2@1-  (_builtin_id  x)) -> (id2@2-  (_builtin_id  x))
-  [=I.I=] successfully defined id2@/1-,2-/.
-  [=^.^=] coh id2@/1-,2-/- = (id2@2-  (_builtin_id  x)) -> (id2@1-  (_builtin_id  x))
-  [=I.I=] successfully defined id2@/1-,2-/-.
-  [=^.^=] coh id2@/1,2/ = (id2@1  (_builtin_id  x)) -> (id2@2  (_builtin_id  x))
-  [=I.I=] successfully defined id2@/1,2/.
-  [=^.^=] coh id2@/1,2/- = (id2@2  (_builtin_id  x)) -> (id2@1  (_builtin_id  x))
-  [=I.I=] successfully defined id2@/1,2/-.
+  [=^.^=] coh id2@/1-/2-/ = (id2@1-  (_builtin_id  x)) -> (id2@2-  (_builtin_id  x))
+  [=I.I=] successfully defined id2@/1-/2-/.
+  [=^.^=] coh id2@/1-/2-/- = (id2@2-  (_builtin_id  x)) -> (id2@1-  (_builtin_id  x))
+  [=I.I=] successfully defined id2@/1-/2-/-.
+  [=^.^=] coh id2@/1/2/ = (id2@1  (_builtin_id  x)) -> (id2@2  (_builtin_id  x))
+  [=I.I=] successfully defined id2@/1/2/.
+  [=^.^=] coh id2@/1/2/- = (id2@2  (_builtin_id  x)) -> (id2@1  (_builtin_id  x))
+  [=I.I=] successfully defined id2@/1/2/-.
   [=^.^=] coh id2@2@1U = (_builtin_comp  (id2@2  (_builtin_id  x)) (id2@1-  (_builtin_id  x))) -> (_builtin_id  (_builtin_comp  (_builtin_id  x) (_builtin_id  x)))
   [=I.I=] successfully defined id2@2@1U.
   [=^.^=] coh id2@2@1U- = (_builtin_id  (_builtin_comp  (_builtin_id  x) (_builtin_id  x))) -> (_builtin_comp  (id2@2  (_builtin_id  x)) (id2@1-  (_builtin_id  x)))
@@ -606,8 +612,8 @@
   [=I.I=] successfully defined exch-.
   [=^.^=] coh exchU = (_builtin_comp  (exch  a b) (exch-  a b)) -> (_builtin_id  (_builtin_comp  (rew2@1  a h) (rew2@2  g b)))
   [=I.I=] successfully defined exchU.
-  [=^.^=] let eh = (comp5  (rew2A  (rew2@1id@2-  a) (rew2@2id@1-  b)) (red3F  (id2@2-  (_builtin_id  x)) (rew2@1  a (_builtin_id  x)) (id2@2@1U  x) (rew2@2  (_builtin_id  x) b) (id2@1  (_builtin_id  x))) (rew3A  (id2@/1-,2-/-  x) (exch  a b) (id2@/1,2/  x)) (red3F-  (id2@1-  (_builtin_id  x)) (rew2@2  (_builtin_id  x) b) (id2@1@2U-  x) (rew2@1  a (_builtin_id  x)) (id2@2  (_builtin_id  x))) (rew2A  (rew2@2id@1  b) (rew2@1id@2  a)))
-  [=I.I=] successfully defined term (!2comp5 (!1rew2A (rew2@1id@2- a) (rew2@2id@1- b)) (!2builtin_comp2 (!1focus3 (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)) (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))) (!2builtin_comp2 (!1rew5@3 (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2@1U x) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))) (!1id5@3F (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))))) (!1rew3A (id2@/1-,2-/- x) (exch a b) (id2@/1,2/ x)) (!2builtin_comp2 (!2builtin_comp2 (!1id5@3F- (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x))) (!1rew5@3 (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1@2U- x) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)))) (!1focus3- (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x)) (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)))) (!1rew2A (rew2@2id@1 b) (rew2@1id@2 a))) of type (!1builtin_comp2 a b) -> (!1builtin_comp2 b a).
+  [=^.^=] let eh = (comp5  (rew2A  (rew2@1id@2-  a) (rew2@2id@1-  b)) (red3F  (id2@2-  (_builtin_id  x)) (rew2@1  a (_builtin_id  x)) (id2@2@1U  x) (rew2@2  (_builtin_id  x) b) (id2@1  (_builtin_id  x))) (rew3A  (id2@/1-/2-/-  x) (exch  a b) (id2@/1/2/  x)) (red3F-  (id2@1-  (_builtin_id  x)) (rew2@2  (_builtin_id  x) b) (id2@1@2U-  x) (rew2@1  a (_builtin_id  x)) (id2@2  (_builtin_id  x))) (rew2A  (rew2@2id@1  b) (rew2@1id@2  a)))
+  [=I.I=] successfully defined term (!2comp5 (!1rew2A (rew2@1id@2- a) (rew2@2id@1- b)) (!2builtin_comp2 (!1focus3 (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)) (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))) (!2builtin_comp2 (!1rew5@3 (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2@1U x) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))) (!1id5@3F (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x))))) (!1rew3A (id2@/1-/2-/- x) (exch a b) (id2@/1/2/ x)) (!2builtin_comp2 (!2builtin_comp2 (!1id5@3F- (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x))) (!1rew5@3 (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1@2U- x) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)))) (!1focus3- (id2@1- (builtin_id x)) (rew2@2 (builtin_id x) b) (id2@1 (builtin_id x)) (id2@2- (builtin_id x)) (rew2@1 a (builtin_id x)) (id2@2 (builtin_id x)))) (!1rew2A (rew2@2id@1 b) (rew2@1id@2 a))) of type (!1builtin_comp2 a b) -> (!1builtin_comp2 b a).
 
   $ catt coverage/eckmann-hilton-optimized.catt
   [=^.^=] coh unitl = (_builtin_comp  (_builtin_id  _) f) -> f

--- a/test.t/run.t
+++ b/test.t/run.t
@@ -67,6 +67,8 @@
   [=I.I=] successfully defined simpl.
   [=^.^=] check (comp  (sq  f) (cbd  f))
   [=I.I=] valid term (comp (comp f f) (comp f (comp f f))) of type x -> x.
+  [=^.^=] let comp-bis = (comp  f g)
+  [=I.I=] successfully defined term (comp f g) of type x -> z.
 
   $ catt features/builtins.catt
   [=^.^=] coh unit = (_builtin_comp  f (_builtin_id  _)) -> f


### PR DESCRIPTION
This merge request adds 2 things:
- parsing for compact ps form like `(x(f)y(g)z)` inside let definitions
- support for writing coma-separated arguments of the same type in a context e.g.: `(x, y : *)`