### PR TITLE
fix landmarks dependency issue

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -1,9 +1,0 @@
-(lang dune 3.7)
-
-(context default)
-(context
-  (default
-     (name profiling)
-     (instrument_with landmarks)
-     (env
-       (_ (env-vars ("OCAML_LANDMARKS" "output=profile.txt"))))))

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,0 +1,9 @@
+(lang dune 3.7)
+
+(context default)
+
+(context
+  (default
+    (name profiling)
+    (instrument_with landmarks)
+    (env (_ (env-vars ("OCAML_LANDMARKS" "output=profile.txt"))))))


### PR DESCRIPTION
From now on, in order to get the profiler, one has to compile with:
```
dune build --workspace dune-workspace.dev
```

and to run catt with the profiler activated:
```
dune exec --context profiling -- catt file.catt
```
